### PR TITLE
Fixes #80: Use inline references to shorten the schema

### DIFF
--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -5,6 +5,18 @@
     "config": {
       "displayFields": ["enabled", "addonId", "os"],
       "schema": {
+        "definitions": {
+          "minVersion": {
+            "type": "string",
+            "title": "Min version",
+            "description": "The mininum version."
+          },
+          "maxVersion": {
+            "type": "string",
+            "title": "Max version",
+            "description": "The maximum version."
+          }
+        },
         "title": "Add-on",
         "description": "Add-on",
         "type": "object",
@@ -73,17 +85,8 @@
                 "vulnerabilityStatus": ""
               },
               "properties": {
-                "minVersion": {
-                  "type": "string",
-                  "title": "Min version",
-                  "description": "The mininum version."
-                },
-                "maxVersion": {
-                  "type": "string",
-                  "title": "Max version",
-                  "description": "The maximum version.",
-                  "default": ""
-                },
+                "minVersion": {"$ref": "#/definitions/minVersion"},
+                "maxVersion": {"$ref": "#/definitions/maxVersion"},
                 "severity": {
                   "type": "string",
                   "title": "Severity",
@@ -145,16 +148,8 @@
                           "Android"
                         ]
                       },
-                      "minVersion": {
-                        "type": "string",
-                        "title": "Min version",
-                        "description": "The mininum version."
-                      },
-                      "maxVersion": {
-                        "type": "string",
-                        "title": "Max version",
-                        "description": "The maximum version."
-                      }
+                      "minVersion": {"$ref": "#/definitions/minVersion"},
+                      "maxVersion": {"$ref": "#/definitions/maxVersion"}
                     }
                   }
                 }
@@ -417,6 +412,18 @@
     "config": {
       "displayFields": ["enabled", "os", "matchName", "matchFilename", "matchDescription"],
       "schema": {
+        "definitions": {
+          "minVersion": {
+            "type": "string",
+            "title": "Min version",
+            "description": "The mininum version."
+          },
+          "maxVersion": {
+            "type": "string",
+            "title": "Max version",
+            "description": "The maximum version."
+          }
+        },
         "title": "Plugin",
         "description": "A blocked plugin entry.",
         "type": "object",
@@ -486,17 +493,8 @@
                 "vulnerabilityStatus": ""
               },
               "properties": {
-                "minVersion": {
-                  "type": "string",
-                  "title": "Min version",
-                  "description": "The mininum version."
-                },
-                "maxVersion": {
-                  "type": "string",
-                  "title": "Max version",
-                  "description": "The maximum version.",
-                  "default": ""
-                },
+                "minVersion": {"$ref": "#/definitions/minVersion"},
+                "maxVersion": {"$ref": "#/definitions/maxVersion"},
                 "severity": {
                   "type": "string",
                   "title": "Severity",
@@ -558,16 +556,8 @@
                           "Android"
                         ]
                       },
-                      "minVersion": {
-                        "type": "string",
-                        "title": "Min version",
-                        "description": "The mininum version."
-                      },
-                      "maxVersion": {
-                        "type": "string",
-                        "title": "Max version",
-                        "description": "The maximum version."
-                      }
+                      "minVersion": {"$ref": "#/definitions/minVersion"},
+                      "maxVersion": {"$ref": "#/definitions/maxVersion"}
                     }
                   }
                 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Tested in kinto-admin.\""
   },
   "dependencies": {
-    "kinto-admin": "^0.9.0"
+    "kinto-admin": "^0.10.1"
   },
   "devDependencies": {
     "fake-indexeddb": "1.0.3"


### PR DESCRIPTION
Fixes #80

@n1k0 what do you think?

Ideally, if we'd like to have a (much?) shorter schema, we'd need something
like a "root" definitions section (at kinto-admin's level), but I'm not we want
that ;)