### PR TITLE
Remove Why and Who in GFX details.

### DIFF
--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -535,8 +535,8 @@
               "bug",
               "created"
             ],
-            "why": {"ui:widget": "textarea"},
-            "who": {"ui:widget": "textarea"},
+            "why": {"ui:widget": "hidden"},
+            "who": {"ui:widget": "hidden"},
             "created": {"ui:readonly": true}
           }
         }


### PR DESCRIPTION
Remove why and who from the GFX details.

Question: Should we just hide them?