### PR TITLE
For addons, min, max and severity should be required and appear by default

### DIFF
--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -80,11 +80,17 @@
               "title": "Versions",
               "description": "The list of impacted versions.",
               "default": [],
+              "minItems": 1,
               "items": {
                 "type": "object",
                 "title": "Version range",
                 "description": "Version range",
                 "additionalProperties": false,
+                "required": [
+                  "minVersion",
+                  "maxVersion",
+                  "severity"
+                ],
                 "default": {
                   "minVersion": "",
                   "maxVersion": "",


### PR DESCRIPTION
Fixes #108