### PR TITLE
Update RegExp field descriptions.

### DIFF
--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -657,17 +657,17 @@
             "matchName": {
               "type": "string",
               "title": "Name match",
-              "description": "A plugin name pattern to match."
+              "description": "A plugin name pattern to match (JavaScript RegExp syntax)."
             },
             "matchFilename": {
               "type": "string",
               "title": "Filename match",
-              "description": "A plugin filename pattern to match."
+              "description": "A plugin filename pattern to match (JavaScript RegExp syntax)."
             },
             "matchDescription": {
               "type": "string",
               "title": "Description match",
-              "description": "A plugin description pattern to match."
+              "description": "A plugin description pattern to match (JavaScript RegExp syntax)."
             },
             "infoURL": {
               "type": "string",

--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -54,7 +54,7 @@
             "guid": {
               "type": "string",
               "title": "Add-on id",
-              "description": "The add-on unique identifier or a regular expression.",
+              "description": "The add-on unique identifier or a regular expression. In case of a RegExp, it must conform to the JavaScript syntax, enclosed within slashes (/).",
               "minLength": 1,
               "default": ""
             },
@@ -657,17 +657,17 @@
             "matchName": {
               "type": "string",
               "title": "Name match",
-              "description": "A plugin name pattern to match (JavaScript RegExp syntax)."
+              "description": "A plugin name pattern to match (JavaScript regular expression syntax)."
             },
             "matchFilename": {
               "type": "string",
               "title": "Filename match",
-              "description": "A plugin filename pattern to match (JavaScript RegExp syntax)."
+              "description": "A plugin filename pattern to match (JavaScript regular expression syntax)."
             },
             "matchDescription": {
               "type": "string",
               "title": "Description match",
-              "description": "A plugin description pattern to match (JavaScript RegExp syntax)."
+              "description": "A plugin description pattern to match (JavaScript regular expression syntax)."
             },
             "infoURL": {
               "type": "string",

--- a/amo-blocklist.json
+++ b/amo-blocklist.json
@@ -54,7 +54,7 @@
             "guid": {
               "type": "string",
               "title": "Add-on id",
-              "description": "The add-on unique identifier or a regular expression. In case of a RegExp, it must conform to the JavaScript syntax, enclosed within slashes (/).",
+              "description": "The add-on unique identifier or a regular expression.",
               "minLength": 1,
               "default": ""
             },
@@ -192,6 +192,9 @@
           ],
           "id": {
             "ui:widget": "hidden"
+          },
+          "guid": {
+            "ui:help": "In case of a RegExp, the value must conform to the JavaScript syntax, enclosed within slashes (/)."
           },
           "schema": {
             "ui:widget": "hidden"
@@ -657,17 +660,17 @@
             "matchName": {
               "type": "string",
               "title": "Name match",
-              "description": "A plugin name pattern to match (JavaScript regular expression syntax)."
+              "description": "A plugin name pattern to match."
             },
             "matchFilename": {
               "type": "string",
               "title": "Filename match",
-              "description": "A plugin filename pattern to match (JavaScript regular expression syntax)."
+              "description": "A plugin filename pattern to match."
             },
             "matchDescription": {
               "type": "string",
               "title": "Description match",
-              "description": "A plugin description pattern to match (JavaScript regular expression syntax)."
+              "description": "A plugin description pattern to match."
             },
             "infoURL": {
               "type": "string",
@@ -812,6 +815,12 @@
           },
           "matchName": {
             "ui:widget": "hidden"
+          },
+          "matchFilename": {
+            "ui:help": "The value must conform to the RegExp JavaScript syntax, with expression delimiters omitted (no /)."
+          },
+          "matchDescription": {
+            "ui:help": "The value must conform to the RegExp JavaScript syntax, with expression delimiters omitted (no /)."
           },
           "details": {
             "ui:order": [


### PR DESCRIPTION
Reference discussion on #storage on IRC:

```
11:53 <TheOne> NiKo`: I am currently looking at a plugin block
11:53 <TheOne> you can enter a filename to block, and the label says "A plugin filename pattern to match."
11:53 <TheOne> is that meant to be a regex? Or a unix filename pattern?
11:53 <NiKo`> ah in the Kinto admin, ok
11:54 <NiKo`> well we basically ported the feature from the Django app, I don't precisely remember but it should be the same as nbefore
11:54 <NiKo`> maybe leplatrem remembers what the client side implementation is?
11:54 <TheOne> hm. It looks like all previous block entries use regular expressions for filenames
11:55 <TheOne> I asked Jorge for confirmation, maybe we can update the label for that field? It's a bit confusing to me
11:56 <NiKo`> yeah if they're actual regexes it's worth stating it clearly
11:56 <NiKo`> will update
11:56 <leplatrem> TheOne, NiKo`: it is probably a regexp
```

/cc @leplatrem @Natim @jvillalobos